### PR TITLE
Add delay to random_yearly_playable_pulse events

### DIFF
--- a/common/on_action/LIDA_random_events.txt
+++ b/common/on_action/LIDA_random_events.txt
@@ -1,5 +1,6 @@
 ﻿random_yearly_playable_pulse = {
 	on_actions = {
+		delay = { days = { 0 200 } }
 		lida_yearly_random_player_pulse
 	}
 }

--- a/common/on_action/LIDA_random_events.txt
+++ b/common/on_action/LIDA_random_events.txt
@@ -25,6 +25,6 @@ lida_yearly_random_player_pulse = {
 		200 = LIDA.135 # you offer a sub a collar
 		200 = LIDA.145 # you offer a sub a harness
 		50 = LIDA.150 # someone offers to craft skimpy plate armor for you
-		10 = 0
+		200 = 0 # Nothing happens this year
 	} 
 }

--- a/common/on_action/LIDA_random_events.txt
+++ b/common/on_action/LIDA_random_events.txt
@@ -25,6 +25,6 @@ lida_yearly_random_player_pulse = {
 		200 = LIDA.135 # you offer a sub a collar
 		200 = LIDA.145 # you offer a sub a harness
 		50 = LIDA.150 # someone offers to craft skimpy plate armor for you
-		200 = 0 # Nothing happens this year
+		10 = 0
 	} 
 }

--- a/events/LIDA_events.txt
+++ b/events/LIDA_events.txt
@@ -48,7 +48,7 @@ LIDA.50 = {
 			save_temporary_scope_as = affairs_candidate
 			# TODO need to check if list is empty?
 			weight = {
-				base = 50
+				base = 1
 				# TODO if the root character is a deviant/sadist, then having negative opinion actually makes them more likely as a partner (hate fuck) 
 				opinion_modifier = {
 					opinion_target = root
@@ -63,13 +63,12 @@ LIDA.50 = {
 					add = {
 						value = attraction
 						divide = high_positive_attraction
-						multiply = 50
 					}
 				}
 				# if you've previously had relations with this person then weight them highly
 				# either one of you should be the dom of the other
 				modifier = {
-					add = 1000
+					add = 0.2
 					has_opinion_modifier = {
 						target = root
 						modifier = dominant_opinion
@@ -254,13 +253,12 @@ LIDA.100 = {
 			}
 			save_temporary_scope_as = affairs_candidate
 			weight = {
-				base = 50
-				# add based on attraction
+				base = 1
+				# add based on attraction, up to +100%
 				modifier = {
 					add = {
 						value = attraction
 						divide = high_positive_attraction
-						multiply = 50
 					}
 				}
 				# more likely if they have extra coins to spare
@@ -272,7 +270,7 @@ LIDA.100 = {
 				# if you've already had an affair with this person then they're unlikely to pay you for it
 				# however, it's still more likely than not since they know you're open for it, so it's not as big of a factor
 				modifier = {
-					add = 20
+					add = 0.4
 					has_opinion_modifier = {
 						target = root
 						modifier = dominant_opinion
@@ -492,13 +490,13 @@ LIDA.110 = {
 			}
 			save_temporary_scope_as = affairs_candidate
 			weight = {
-				base = 50
-				# add based on attraction
+				base = 1
+
+				# add based on attraction, up to +100%
 				modifier = {
 					add = {
 						value = attraction
 						divide = high_positive_attraction
-						multiply = 50
 					}
 				}
 
@@ -530,7 +528,6 @@ LIDA.110 = {
 					add = {
 						value = ai_boldness
 						divide = dominant_positive_ai_value
-						multiply = 50
 					}
 				}
 			}
@@ -629,11 +626,11 @@ LIDA.120 = {
 			}
 			save_temporary_scope_as = affairs_candidate
 			weight = {
-				base = 50
+				base = 1
 
 				# more likely if they are sexually frustrated
 				modifier = {
-					add = 100
+					add = 2
 					has_character_modifier = sexually_frustrated
 				}
 
@@ -642,7 +639,6 @@ LIDA.120 = {
 					add = {
 						value = ai_boldness
 						divide = dominant_positive_ai_value
-						multiply = 50
 					}
 				}
 			}
@@ -797,14 +793,13 @@ LIDA.130 = {
 			}
 			save_temporary_scope_as = affairs_candidate
 			weight = {
-				base = 50
+				base = 1
 
 				# more likely if they are bold
 				modifier = {
 					add = {
 						value = ai_boldness
 						divide = dominant_positive_ai_value
-						multiply = 50
 					}
 				}
 			}
@@ -946,14 +941,14 @@ LIDA.135 = {
 			}
 			save_temporary_scope_as = affairs_candidate
 			weight = {
-				base = 50
+				base = 1
 
 				# less likely if they are bold
 				modifier = {
 					add = {
 						value = ai_boldness
 						divide = dominant_positive_ai_value
-						multiply = -50
+						multiply = -1
 					}
 				}
 			}
@@ -1247,14 +1242,13 @@ LIDA.140 = {
 				they_dom_you_strongly = yes
 			}
 			weight = {
-				base = 50
+				base = 1
 
 				# more likely if they are bold
 				modifier = {
 					add = {
 						value = ai_boldness
 						divide = dominant_positive_ai_value
-						multiply = 50
 					}
 				}
 			}
@@ -1397,14 +1391,14 @@ LIDA.145 = {
 			}
 			save_temporary_scope_as = affairs_candidate
 			weight = {
-				base = 50
+				base = 1
 
 				# less likely if they are bold
 				modifier = {
 					add = {
 						value = ai_boldness
 						divide = dominant_positive_ai_value
-						multiply = -50
+						multiply = -1
 					}
 				}
 			}

--- a/events/LIDA_events.txt
+++ b/events/LIDA_events.txt
@@ -48,7 +48,7 @@ LIDA.50 = {
 			save_temporary_scope_as = affairs_candidate
 			# TODO need to check if list is empty?
 			weight = {
-				base = 1
+				base = 50
 				# TODO if the root character is a deviant/sadist, then having negative opinion actually makes them more likely as a partner (hate fuck) 
 				opinion_modifier = {
 					opinion_target = root
@@ -63,12 +63,13 @@ LIDA.50 = {
 					add = {
 						value = attraction
 						divide = high_positive_attraction
+						multiply = 50
 					}
 				}
 				# if you've previously had relations with this person then weight them highly
 				# either one of you should be the dom of the other
 				modifier = {
-					add = 0.2
+					add = 1000
 					has_opinion_modifier = {
 						target = root
 						modifier = dominant_opinion
@@ -253,12 +254,13 @@ LIDA.100 = {
 			}
 			save_temporary_scope_as = affairs_candidate
 			weight = {
-				base = 1
-				# add based on attraction, up to +100%
+				base = 50
+				# add based on attraction
 				modifier = {
 					add = {
 						value = attraction
 						divide = high_positive_attraction
+						multiply = 50
 					}
 				}
 				# more likely if they have extra coins to spare
@@ -270,7 +272,7 @@ LIDA.100 = {
 				# if you've already had an affair with this person then they're unlikely to pay you for it
 				# however, it's still more likely than not since they know you're open for it, so it's not as big of a factor
 				modifier = {
-					add = 0.4
+					add = 20
 					has_opinion_modifier = {
 						target = root
 						modifier = dominant_opinion
@@ -490,13 +492,13 @@ LIDA.110 = {
 			}
 			save_temporary_scope_as = affairs_candidate
 			weight = {
-				base = 1
-
-				# add based on attraction, up to +100%
+				base = 50
+				# add based on attraction
 				modifier = {
 					add = {
 						value = attraction
 						divide = high_positive_attraction
+						multiply = 50
 					}
 				}
 
@@ -528,6 +530,7 @@ LIDA.110 = {
 					add = {
 						value = ai_boldness
 						divide = dominant_positive_ai_value
+						multiply = 50
 					}
 				}
 			}
@@ -626,11 +629,11 @@ LIDA.120 = {
 			}
 			save_temporary_scope_as = affairs_candidate
 			weight = {
-				base = 1
+				base = 50
 
 				# more likely if they are sexually frustrated
 				modifier = {
-					add = 2
+					add = 100
 					has_character_modifier = sexually_frustrated
 				}
 
@@ -639,6 +642,7 @@ LIDA.120 = {
 					add = {
 						value = ai_boldness
 						divide = dominant_positive_ai_value
+						multiply = 50
 					}
 				}
 			}
@@ -793,13 +797,14 @@ LIDA.130 = {
 			}
 			save_temporary_scope_as = affairs_candidate
 			weight = {
-				base = 1
+				base = 50
 
 				# more likely if they are bold
 				modifier = {
 					add = {
 						value = ai_boldness
 						divide = dominant_positive_ai_value
+						multiply = 50
 					}
 				}
 			}
@@ -941,14 +946,14 @@ LIDA.135 = {
 			}
 			save_temporary_scope_as = affairs_candidate
 			weight = {
-				base = 1
+				base = 50
 
 				# less likely if they are bold
 				modifier = {
 					add = {
 						value = ai_boldness
 						divide = dominant_positive_ai_value
-						multiply = -1
+						multiply = -50
 					}
 				}
 			}
@@ -1242,13 +1247,14 @@ LIDA.140 = {
 				they_dom_you_strongly = yes
 			}
 			weight = {
-				base = 1
+				base = 50
 
 				# more likely if they are bold
 				modifier = {
 					add = {
 						value = ai_boldness
 						divide = dominant_positive_ai_value
+						multiply = 50
 					}
 				}
 			}
@@ -1391,14 +1397,14 @@ LIDA.145 = {
 			}
 			save_temporary_scope_as = affairs_candidate
 			weight = {
-				base = 1
+				base = 50
 
 				# less likely if they are bold
 				modifier = {
 					add = {
 						value = ai_boldness
 						divide = dominant_positive_ai_value
-						multiply = -1
+						multiply = -50
 					}
 				}
 			}


### PR DESCRIPTION
Why? Because random_yearly_playable_pulse triggers at the same time as random_yearly_playable_pulse from other mods (for the same character), which results in multiple different events popping up at the same time.