### PR TITLE
Add delay to random_yearly_playable_pulse events

### DIFF
--- a/common/on_action/LIDA_random_events.txt
+++ b/common/on_action/LIDA_random_events.txt
@@ -1,5 +1,6 @@
 ﻿random_yearly_playable_pulse = {
 	on_actions = {
+		delay = { days = { 0 200 } }
 		lida_yearly_random_player_pulse
 	}
 }


### PR DESCRIPTION
Why? Because random_yearly_playable_pulse triggers at the same time as random_yearly_playable_pulse from other mods (for the same character).